### PR TITLE
Update faqs.md header

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -4,8 +4,7 @@ hide:
   - toc
 --- -->
 
-FAQs
-----
+# FAQs
 
 1. What can I do on the HEAL Platform?  
       


### PR DESCRIPTION
Updated header indication (___ to #) to conform to the rest of the markdown files. the current format creates a superfluous endpoint, (https://heal.github.io/platform-documentation/faqs/#faqs). The talk of deprecating urls users have already bookmarked had me looking around.