### PR TITLE
add info to study reg pages for clarity

### DIFF
--- a/docs/study-registration/registering-your-study.md
+++ b/docs/study-registration/registering-your-study.md
@@ -46,6 +46,7 @@ study you wish to register:
     [contact us](mailto:heal-support@datacommons.io) with those details.
 - Enter the unique ID for your study within the repository.
 - Submit your registration.
+- After you register your study, the study will disappear from the HEAL Data Platform for about 24 hours while we sync the study record with the new CEDAR form. You do not need to do anything for it to reappear. 
 
 Alternate steps to register a study:
 

--- a/docs/study-registration/requesting-access.md
+++ b/docs/study-registration/requesting-access.md
@@ -15,7 +15,7 @@
 ## Step 2: Find your study
 
 From the [Discovery Page](https://healdata.org/portal/discovery), find the study you
-wish to request access to register.
+wish to request access to register. *(If you cannot find your study, contact us at heal-support@datacommons.io.)*
 
 - Click on the study to open the Study Page
 - At the top of the Study Page, select `Request Access to Register This Study`


### PR DESCRIPTION
HP-1215 and HP-1256
https://ctds-planx.atlassian.net/browse/HP-1215 - tell PIs the study record temporarily disappears from platform after registering
and
https://ctds-planx.atlassian.net/browse/HP-1256 - Add a line about what to do if you can’t find your study