### PR TITLE
add redirects plugin to allow redirecting old doc page links

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -72,6 +72,9 @@ markdown_extensions:
   - pymdownx.details
 plugins:
   - search
+  - redirects:
+      redirect_maps:
+        'vlmd_submission.md': 'vlmd/index.md'
   - mkdocs-video:
       is_video: True
 


### PR DESCRIPTION
To allow us to smoothly redirect people using obsolete documentation pages to the updated page link, we are adding the redirects mkdocs plugin. (and also a redirect from https://heal.github.io/platform-documentation/vlmd_submission/ to https://heal.github.io/platform-documentation/vlmd/)